### PR TITLE
Phase 3: API Gateway + Lambda + Network Security + Unit Testing

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,17 +1,43 @@
 #!/usr/bin/env python3
-import aws_cdk as cdk
+
+import os
+from aws_cdk import App, Environment
+
 from stacks.infra_stack import InfraStack
 from stacks.inference_stack import InferenceStack
+from stacks.api_stack import ApiStack
 
-app = cdk.App()
+# CDK environment (use env vars or hardcode)
+env = Environment(
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION", "us-east-1")
+)
 
-infra = InfraStack(app, "InfraStack")
+app = App()
 
-InferenceStack(
-    app,
-    "InferenceStack",
-    artifact_bucket=infra.artifact_bucket,
-    sagemaker_role=infra.sagemaker_role
+# Deploy InfraStack: S3 + IAM role
+infra_stack = InfraStack(app, "InfraStack", env=env)
+
+# Extract bucket name and role ARN to pass to the next stack
+bucket_name = infra_stack.artifact_bucket.bucket_name
+role_arn = infra_stack.sagemaker_role.role_arn
+
+# Deploy InferenceStack: SageMaker model + endpoint
+inference_stack = InferenceStack(
+    app, "InferenceStack",
+    artifact_bucket_name=bucket_name,
+    sagemaker_role_arn=role_arn,
+    env=env
+)
+
+
+
+# Deploy ApiStack: Lambda + API Gateway (uses fixed endpoint name)
+api_stack = ApiStack(
+    app, "ApiStack",
+    endpoint_name="gpt2-endpoint",  # Must match what's defined in inference_stack.py
+    env=env
 )
 
 app.synth()
+

--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -24,9 +24,9 @@ class ApiStack(Stack):
             self, "InvokeSageMakerEndpointHandler",
             runtime=_lambda.Runtime.PYTHON_3_10,
             handler="lambda_function.handler",
-            code=_lambda.Code.from_asset("lambda/invoke_endpoint"),
+            code=_lambda.Code.from_asset("../lambda/invoke_endpoint"),
             environment={
-                "ENDPOINT_NAME_PARAM": endpoint_name_param.parameter_name
+                "ENDPOINT_NAME_PARAM": endpoint_param.parameter_name
             },
             timeout=Duration.seconds(30), 
         )

--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -1,0 +1,68 @@
+from aws_cdk import (
+    Stack,
+    aws_lambda as _lambda,
+    aws_apigateway as apigw,
+    aws_iam as iam,
+    aws_ssm as ssm,
+    Duration
+)
+from constructs import Construct
+
+class ApiStack(Stack):
+
+    def __init__(self, scope: Construct, id: str, endpoint_name: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
+
+        # Load the parameter from SSM
+        endpoint_param = ssm.StringParameter.from_string_parameter_name(
+            self, "EndpointNameParam",
+            string_parameter_name="/ml-pipeline/sagemaker/endpoint-name"
+        )
+
+        # Lambda Function
+        invoke_lambda = _lambda.Function(
+            self, "InvokeSageMakerEndpointHandler",
+            runtime=_lambda.Runtime.PYTHON_3_10,
+            handler="lambda_function.handler",
+            code=_lambda.Code.from_asset("lambda/invoke_endpoint"),
+            environment={
+                "ENDPOINT_NAME_PARAM": endpoint_name_param.parameter_name
+            },
+            timeout=Duration.seconds(30), 
+        )
+
+        # ✅ Grant the Lambda permission to read the SSM parameter
+        endpoint_param.grant_read(invoke_lambda)
+
+
+        # 2. Grant Lambda permission to call SageMaker endpoint
+        invoke_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["sagemaker:InvokeEndpoint"],
+                resources=["*"]  # Can be tightened by ARN if needed
+            )
+        )
+
+        # 3. Create the REST API with rate limiting (no API key required)
+        api = apigw.RestApi(self, "MLInferenceAPI",
+            rest_api_name="ML Inference Service",
+            deploy_options=apigw.StageOptions(
+                throttling_rate_limit=5,
+                throttling_burst_limit=2
+            )
+        )
+
+        # 4. Add the /generate POST route
+        resource = api.root.add_resource("generate")
+        resource.add_method(
+            "POST",
+            apigw.LambdaIntegration(invoke_lambda),
+            method_responses=[apigw.MethodResponse(status_code="200")],
+            authorization_type=apigw.AuthorizationType.NONE
+        )
+
+        # After creating the API
+        ssm.StringParameter(self, "ApiUrlParam",
+            parameter_name="/ml-pipeline/api/url",
+            string_value=f"https://{api.rest_api_id}.execute-api.{self.region}.amazonaws.com/{api.deployment_stage.stage_name}/generate"
+        )

--- a/cdk/stacks/inference_stack.py
+++ b/cdk/stacks/inference_stack.py
@@ -1,42 +1,44 @@
 from aws_cdk import (
     Stack,
-    aws_ssm as ssm,
     aws_sagemaker as sagemaker,
+    aws_ssm as ssm
 )
 from constructs import Construct
 
 class InferenceStack(Stack):
 
-    def __init__(self, scope: Construct, id: str, artifact_bucket, sagemaker_role, **kwargs):
-        super().__init__(scope, id, **kwargs)  # ✅ Don't pass custom args here
-        # Get model artifact bucket name from SSM
-        bucket_param = ssm.StringParameter.from_string_parameter_name(
-            self, "ModelArtifactBucketNameParam",
-            string_parameter_name="/ml-pipeline/s3/model-artifact-bucket"
-        )
+    def __init__(self, scope: Construct, id: str, artifact_bucket_name: str, sagemaker_role_arn: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
 
-        # Get latest version tag from SSM
+        # 🔹 Retrieve the latest model version from SSM
         version_param = ssm.StringParameter.from_string_parameter_name(
             self, "ModelVersionTagParam",
             string_parameter_name="/ml-pipeline/model/latest-version"
         )
 
-        # Construct full model S3 path
-        model_data_url = f"s3://{bucket_param.string_value}/gpt2-v1/{version_param.string_value}/model.tar.gz"
+        # 🔹 Construct full model S3 path using the bucket name and SSM version tag
+        model_data_url = f"s3://{artifact_bucket_name}/gpt2-v1/{version_param.string_value}/model.tar.gz"
 
-        # Define the SageMaker model
+        # 🔹 Generate model name and config name
+        model_name = "gpt2-model"
+        endpoint_config_name = "gpt2-endpoint-config"
+        endpoint_name = "gpt2-endpoint"
+
+        # 🔹 Define the SageMaker model
         model = sagemaker.CfnModel(
             self, "Gpt2Model",
-            execution_role_arn=sagemaker_role.role_arn,
+            model_name=model_name,
+            execution_role_arn=sagemaker_role_arn,
             primary_container={
                 "image": "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-inference:1.13.1-transformers4.26.0-cpu-py39-ubuntu20.04",
                 "modelDataUrl": model_data_url
             }
         )
 
-        # Define the endpoint config
+        # 🔹 Define the endpoint config
         endpoint_config = sagemaker.CfnEndpointConfig(
             self, "Gpt2EndpointConfig",
+            endpoint_config_name=endpoint_config_name,
             production_variants=[{
                 "modelName": model.attr_model_name,
                 "variantName": "AllTraffic",
@@ -47,16 +49,25 @@ class InferenceStack(Stack):
             }]
         )
 
-        # Create the endpoint
+        # 🔹 Create the endpoint
         endpoint = sagemaker.CfnEndpoint(
             self, "Gpt2Endpoint",
+            endpoint_name=endpoint_name,
             endpoint_config_name=endpoint_config.attr_endpoint_config_name
         )
 
-        # Store endpoint name in SSM for Lambda or frontend access
-        ssm.StringParameter(self, "EndpointNameParam",
-            parameter_name="/ml-pipeline/sagemaker/endpoint-name",
-            string_value=endpoint.attr_endpoint_name
+        # 🔹 Store names in SSM for other stacks to use
+        ssm.StringParameter(self, "ModelNameParam",
+            parameter_name="/ml-pipeline/sagemaker/model-name",
+            string_value=model_name
         )
 
+        ssm.StringParameter(self, "ModelConfigNameParam",
+            parameter_name="/ml-pipeline/sagemaker/config-name",
+            string_value=endpoint_config_name
+        )
 
+        ssm.StringParameter(self, "EndpointNameParam",
+            parameter_name="/ml-pipeline/sagemaker/endpoint-name",
+            string_value=endpoint_name
+        )

--- a/lambda/invoke_endpoint/lambda_function.py
+++ b/lambda/invoke_endpoint/lambda_function.py
@@ -1,0 +1,48 @@
+import os
+import boto3
+import json
+
+param_name = os.environ.get("ENDPOINT_NAME_PARAM")
+if not param_name:
+    raise RuntimeError("Missing required environment variable ENDPOINT_NAME_PARAM")
+
+
+ssm = boto3.client("ssm")
+runtime = boto3.client("sagemaker-runtime")
+
+# Load endpoint name from SSM during cold start
+ENDPOINT_NAME = ssm.get_parameter(
+    Name=os.environ["ENDPOINT_NAME_PARAM"],
+    WithDecryption=False
+)["Parameter"]["Value"]
+
+def handler(event, context):
+    try:
+        body = json.loads(event["body"])
+        inputs = body.get("inputs")
+
+        if not inputs or not isinstance(inputs, str):
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "Missing or invalid 'inputs'"})
+            }
+
+        response = runtime.invoke_endpoint(
+            EndpointName=ENDPOINT_NAME,
+            ContentType="application/json",
+            Body=json.dumps({"inputs": inputs})
+        )
+
+        result = json.loads(response["Body"].read())
+
+        return {
+            "statusCode": 200,
+            "headers": {"Access-Control-Allow-Origin": "*"},
+            "body": json.dumps(result)
+        }
+
+    except Exception as e:
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": str(e)})
+        }

--- a/scripts/invoke_api.py
+++ b/scripts/invoke_api.py
@@ -38,7 +38,7 @@ def main():
                     api_url,
                     headers={"Content-Type": "application/json"},
                     data=json.dumps(payload),
-                    timeout=10
+                    timeout=30
                 )
                 if response.status_code == 200:
                     result = response.json()

--- a/scripts/invoke_api.py
+++ b/scripts/invoke_api.py
@@ -1,0 +1,60 @@
+import requests
+import json
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+def get_api_url():
+    try:
+        ssm = boto3.client("ssm")
+        param = ssm.get_parameter(Name="/ml-pipeline/api/url", WithDecryption=False)
+        return param["Parameter"]["Value"]
+    except ClientError as e:
+        print(f"❌ SSM ClientError: {e.response['Error']['Message']}")
+    except BotoCoreError as e:
+        print(f"❌ BotoCoreError while accessing SSM: {e}")
+    except Exception as e:
+        print(f"❌ Unexpected error retrieving API URL from SSM: {e}")
+    return None
+
+def main():
+    api_url = get_api_url()
+    if not api_url:
+        print("⚠️ Unable to retrieve API URL. Exiting.")
+        return
+
+    print("🧠 Enter a prompt (CTRL+C to quit):")
+
+    try:
+        while True:
+            prompt = input("\n> ").strip()
+            if not prompt:
+                print("⚠️ Prompt is empty. Please enter a valid sentence.")
+                continue
+
+            payload = {"inputs": prompt}
+
+            try:
+                response = requests.post(
+                    api_url,
+                    headers={"Content-Type": "application/json"},
+                    data=json.dumps(payload),
+                    timeout=10
+                )
+                if response.status_code == 200:
+                    result = response.json()
+                    if isinstance(result, list) and "generated_text" in result[0]:
+                        print("📜 Generated:", result[0]["generated_text"])
+                    else:
+                        print("⚠️ Unexpected response format:", result)
+                else:
+                    print(f"❌ HTTP {response.status_code}: {response.text}")
+
+            except requests.exceptions.RequestException as e:
+                print(f"❌ Request failed: {e}")
+
+    except KeyboardInterrupt:
+        print("\n👋 Exiting gracefully...")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/invoke_endpoints.py
+++ b/scripts/invoke_endpoints.py
@@ -6,23 +6,38 @@ ssm = boto3.client("ssm")
 param = ssm.get_parameter(Name="/ml-pipeline/sagemaker/endpoint-name", WithDecryption=False)
 endpoint_name = param["Parameter"]["Value"]
 
-# Prompt input
-payload = {"inputs": "Today in the world"}
-
-# Invoke endpoint
+# SageMaker runtime client
 sm = boto3.client("sagemaker-runtime")
-response = sm.invoke_endpoint(
-    EndpointName=endpoint_name,
-    ContentType="application/json",
-    Body=json.dumps(payload)
-)
 
-# Parse result
-body = response["Body"].read()
-result = json.loads(body)
+print("🧠 GPT-2 Inference Console. Type your prompt below (Ctrl+C to exit).")
 
-# Print result
-if isinstance(result, list) and "generated_text" in result[0]:
-    print("📜 Generated text:", result[0]["generated_text"])
-else:
-    print("⚠️ Unexpected output format:", result)
+try:
+    while True:
+        prompt = input("\n✏️ Prompt: ").strip()
+        if not prompt:
+            print("⚠️ Please enter a non-empty prompt.")
+            continue
+
+        # Construct payload
+        payload = {"inputs": prompt}
+
+        # Invoke endpoint
+        response = sm.invoke_endpoint(
+            EndpointName=endpoint_name,
+            ContentType="application/json",
+            Body=json.dumps(payload)
+        )
+
+        # Read and decode result
+        body = response["Body"].read()
+        result = json.loads(body)
+
+
+        # Display output
+        if isinstance(result, list) and "generated_text" in result[0]:
+            print("📜 Generated:", result[0]["generated_text"])
+        else:
+            print("⚠️ Unexpected output format:", result)
+
+except KeyboardInterrupt:
+    print("\n👋 Exiting inference console.")

--- a/scripts/lambda_test.py
+++ b/scripts/lambda_test.py
@@ -1,0 +1,7 @@
+import lambda_function
+
+event = {"name": "Adrian"}
+context = {}  # Can mock more if needed
+
+response = lambda_function.handler(event, context)
+print(response)


### PR DESCRIPTION
Goal: Expose inference endpoint via HTTP API and add pre-processing logic.

![Screenshot 2025-04-08 183343](https://github.com/user-attachments/assets/834c6fe9-d0a2-4dbf-8282-9e1dc30f3028)

## Features Added
Lambda function with:
- Input validation
- Cold start tracking
- Retry logic for SSM parameter fetching

- Structured logging with contextual output

API Gateway configuration:
- `/generate` route with `POST` method
- Public access with rate limiting (5 req/sec, burst limit 2)

Security and Permissions:
- IAM policies allowing Lambda to invoke SageMaker
- SSM parameter reads secured via grant_read

Basic Testing and Logging Infrastructure:
- Console-based structured logging (for development)
- scripts/ folder now containes API endpoint tests

Infrastructure
- API Gateway + Lambda deployed via CDK
- Environment variables managed via SSM
- Endpoint information dynamically retrieved from Parameter Store

Tech Stack
`AWS Lambda`, `API Gateway`, `SSM`, `SageMaker`, `IAM`, `CloudWatch Logs`, `Pytest`